### PR TITLE
updated .gitignore to include *xcuserstate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
+*.xcuserstate
 
 ## Other
 *.moved-aside


### PR DESCRIPTION
Added *.xcuserstate which contains project directory properties to .gitignore. It kept giving me issues when making changes to my local branches.

It stores things like your workspace/project document layouts, nothing you would lose sleep over if lost:
https://stackoverflow.com/questions/9028118/what-is-userinterfacestate-xcuserstate-file-in-xcode-project